### PR TITLE
Getting rid of bonjour and use bonjour-service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/bonjour": "^3.5.10",
         "@types/multicast-dns": "^7.2.1",
         "@types/uuid": "^9.0.1",
-        "bonjour": "^3.3.0",
+        "bonjour-service": "^1.2.1",
         "logdown": "^3.3.1",
         "multicast-dns": "^7.2.5",
         "uuid": "^9.0.0"
@@ -2366,12 +2366,12 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2429,11 +2429,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/array-flatten": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
@@ -2615,16 +2610,13 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/bonjour": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.3.0.tgz",
-      "integrity": "sha512-Pit4+jWXvwm2ScgOu4xeu2Jg1E3Wc9UfGjrZYPkhtH+BxgYNfa4vfyd9cvfYvChWUTRXKyo4LpCI8BQ5B5mxTw==",
+    "node_modules/bonjour-service": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
+      "integrity": "sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==",
       "dependencies": {
-        "array-flatten": "^2.0.0",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.1",
-        "multicast-dns": "^5.0.0",
-        "multicast-dns-service-types": "^1.1.0"
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.5"
       }
     },
     "node_modules/brace-expansion": {
@@ -2706,11 +2698,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
-    },
-    "node_modules/buffer-indexof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "node_modules/call-bind": {
       "version": "1.0.6",
@@ -3226,11 +3213,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dns-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg=="
-    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -3240,14 +3222,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/dns-txt": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-      "integrity": "sha512-Ix5PrWjphuSoUXV/Zv5gaFHjnaJtb02F2+Si3Ht9dyJ87+Z/lMmy+dpNHtTGraNK958ndXq2i+GLkWsWHcKaBQ==",
-      "dependencies": {
-        "buffer-indexof": "^1.0.0"
       }
     },
     "node_modules/doctrine": {
@@ -3753,8 +3727,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -3776,6 +3749,18 @@
       },
       "engines": {
         "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4135,6 +4120,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/git-raw-commits/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -6081,11 +6075,6 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
-    },
-    "node_modules/multicast-dns-service-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-      "integrity": "sha512-cnAsSVxIDsYt0v7HmC0hWZFwwXSh+E6PgCrREDuN/EsjgLwA5XRmlMHhSiDPrt6HxY1gTivEa/Zh7GtODoLevQ=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@types/bonjour": "^3.5.10",
         "@types/multicast-dns": "^7.2.1",
         "@types/uuid": "^9.0.1",
         "bonjour-service": "^1.2.1",
@@ -20,8 +19,8 @@
       },
       "devDependencies": {
         "@types/node": "^20.8.10",
-        "@typescript-eslint/eslint-plugin": "^6.9.1",
-        "@typescript-eslint/parser": "^6.9.1",
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
         "commitlint": "^18.2.0",
         "eslint": "^8.52.0",
         "eslint-config-prettier": "^9.0.0",
@@ -1743,14 +1742,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/bonjour": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
-      "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/dns-packet": {
       "version": "5.6.5",
       "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
@@ -1886,16 +1877,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.0.tgz",
+      "integrity": "sha512-M72SJ0DkcQVmmsbqlzc6EJgb/3Oz2Wdm6AyESB4YkGgCxP8u5jt5jn4/OBMPK3HLOxcttZq5xbBBU7e2By4SZQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.0.0",
+        "@typescript-eslint/type-utils": "7.0.0",
+        "@typescript-eslint/utils": "7.0.0",
+        "@typescript-eslint/visitor-keys": "7.0.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1912,7 +1903,7 @@
       },
       "peerDependencies": {
         "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1921,15 +1912,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.0.0.tgz",
+      "integrity": "sha512-V2eqnC998a04L5TniVt8qEhw/rp1dRU/9GJfx4128AFeh2WPMpmj5oeF5G9EqTi6z1JdKfLEACRMot5wUxD3pA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.0.0",
+        "@typescript-eslint/types": "7.0.0",
+        "@typescript-eslint/typescript-estree": "7.0.0",
+        "@typescript-eslint/visitor-keys": "7.0.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1940,7 +1931,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1949,13 +1940,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.0.tgz",
+      "integrity": "sha512-IxTStwhNDPO07CCrYuAqjuJ3Xf5MrMaNgbAZPxFXAUpAtwqFxiuItxUaVtP/SJQeCdJjwDGh9/lMOluAndkKeg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "7.0.0",
+        "@typescript-eslint/visitor-keys": "7.0.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1966,13 +1957,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.0.tgz",
+      "integrity": "sha512-FIM8HPxj1P2G7qfrpiXvbHeHypgo2mFpFGoh5I73ZlqmJOsloSa1x0ZyXCer43++P1doxCgNqIOLqmZR6SOT8g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/typescript-estree": "7.0.0",
+        "@typescript-eslint/utils": "7.0.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1984,7 +1975,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1993,9 +1984,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-9ZIJDqagK1TTs4W9IyeB2sH/s1fFhN9958ycW8NRTg1vXGzzH5PQNzq6KbsbVGMT+oyyfa17DfchHDidcmf5cg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2006,13 +1997,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.0.tgz",
+      "integrity": "sha512-JzsOzhJJm74aQ3c9um/aDryHgSHfaX8SHFIu9x4Gpik/+qxLvxUylhTsO9abcNu39JIdhY2LgYrFxTii3IajLA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/types": "7.0.0",
+        "@typescript-eslint/visitor-keys": "7.0.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2034,17 +2025,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.0.tgz",
+      "integrity": "sha512-kuPZcPAdGcDBAyqDn/JVeJVhySvpkxzfXjJq1X1BFSTYo1TTuo4iyb937u457q4K0In84p6u2VHQGaFnv7VYqg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/scope-manager": "7.0.0",
+        "@typescript-eslint/types": "7.0.0",
+        "@typescript-eslint/typescript-estree": "7.0.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2055,16 +2046,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.0.tgz",
+      "integrity": "sha512-JZP0uw59PRHp7sHQl3aF/lFgwOW2rgNVnXUksj1d932PMita9wFBd3621vHQRDvHwPsSY9FMAAHVc8gTvLYY4w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/types": "7.0.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdns-listener-advanced",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdns-listener-advanced",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/bonjour": "^3.5.10",
     "@types/multicast-dns": "^7.2.1",
     "@types/uuid": "^9.0.1",
-    "bonjour": "^3.3.0",
+    "bonjour-service": "^1.2.1",
     "logdown": "^3.3.1",
     "multicast-dns": "^7.2.5",
     "uuid": "^9.0.0"
@@ -96,12 +96,5 @@
   "moduleDirectories": [
     "src"
   ],
-  "overrides": {
-    "glob-parent": "^6.0.2",
-    "yargs-parser": "^21.1.1",
-    "concat-stream": "^2.0.0",
-    "micromatch": "^4.0.5",
-    "ansi-regex": "^3.0.1",
-    "multicast-dns": "^7.2.5"
-  }
+  "overrides": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdns-listener-advanced",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "mDNS listener, add as many .local hostnames to your computer as you like.",
   "author": "aminekun90",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "umd:main": "dist/umd/index.js",
   "types": "dist/types/index.d.js",
   "dependencies": {
-    "@types/bonjour": "^3.5.10",
     "@types/multicast-dns": "^7.2.1",
     "@types/uuid": "^9.0.1",
     "bonjour-service": "^1.2.1",
@@ -71,8 +70,8 @@
   "homepage": "https://github.com/aminekun90/mdns_listener_advanced#readme",
   "devDependencies": {
     "@types/node": "^20.8.10",
-    "@typescript-eslint/eslint-plugin": "^6.9.1",
-    "@typescript-eslint/parser": "^6.9.1",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
     "commitlint": "^18.2.0",
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^9.0.0",

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { EventEmitter } from 'events';
 import { Device, DeviceBuffer, DeviceData, NPM_URL, Options, emittedEvent } from './types';
 import mDNS from 'multicast-dns';
-import bonjour from 'bonjour';
+import { Bonjour, ServiceConfig } from 'bonjour-service';
 import logdown from 'logdown';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -34,7 +34,7 @@ export class Core {
     private logger: logdown.Logger = logdown('MDNS ADVANCED'),
     private mdns = mDNS(),
     private myEvent = new EventEmitter(),
-    private publisher = bonjour(),
+    private publisher = new Bonjour(),
   ) {
     this.hostnames = hostsList ?? [];
     this.mdnsHostsFile = mdnsHostsPath;
@@ -101,7 +101,7 @@ export class Core {
         return this.__getHosts();
       }
       this.logger.warn('Hostnames or path to hostnames is not provided, listening to a host is compromised!');
-      throw new Error(`Provide hostnames or path to hostnames ! Report this error ${NPM_URL}`);
+      throw new Error(`Provide hostnames or path to hostnames! Report this error ${NPM_URL}`);
     }
   }
 
@@ -138,7 +138,7 @@ export class Core {
         uuid: `"${uuidv4()}"`,
         ipv4: JSON.stringify(this.getLocalIpAddress()),
       },
-    } as bonjour.ServiceOptions;
+    } as ServiceConfig;
     const bonjourService = this.publisher.publish(options);
     this.info('A hostname have been published with options', options);
     this.debug(bonjourService);

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -230,11 +230,11 @@ export class Core {
   public stop() {
     this.info('Stopping mdns listener...');
     // fix mdns undefined sometimes
-    if (this.mdns && this.mdns.removeAllListeners instanceof Function) {
+    if (this.mdns?.removeAllListeners) {
       this.mdns.removeAllListeners();
     }
     // fix myEvent undefined
-    if (this.myEvent && this.myEvent.removeAllListeners instanceof Function) {
+    if (this.myEvent?.removeAllListeners) {
       this.myEvent.removeAllListeners();
     }
   }

--- a/src/__test__/Core.test.ts
+++ b/src/__test__/Core.test.ts
@@ -2,94 +2,116 @@ import { expect, jest, describe, beforeAll, afterAll, it, beforeEach, afterEach 
 import { Core } from "@mdns-listener/Core";
 import { NPM_URL } from "@mdns-listener/types";
 import { EventEmitter } from "stream";
-
-jest.mock('multicast-dns', () => {
-    return jest.fn(() => {
-        return {
-            on: jest.fn(),
-            query: jest.fn(),
-            destroy: jest.fn(),
-            emit: jest.fn(),
-        }
-    });
-});
-
-jest.mock('bonjour-service', () => {
-    return {
-        Bonjour: jest.fn().mockImplementation(() => ({
-            publish: jest.fn(),
-            unpublishAll: jest.fn(),
-            destroy: jest.fn(),
-        })),
-    };
-});
-
 import mDNS from 'multicast-dns';
 import { Bonjour } from 'bonjour-service';
 
+jest.mock('multicast-dns', () => {
+  return jest.fn(() => {
+    return {
+      on: jest.fn(),
+      query: jest.fn(),
+      destroy: jest.fn(),
+      emit: jest.fn(),
+      removeAllListeners: jest.fn(),
+    }
+  });
+});
+
+jest.mock('stream', () => {
+  
+    return {
+      EventEmitter: jest.fn(() => ({
+        on: jest.fn(),
+        query: jest.fn(),
+        destroy: jest.fn(),
+        emit: jest.fn(),
+        removeAllListeners: jest.fn(),
+      }))
+    }
+  
+});
+
+jest.mock('bonjour-service', () => {
+  return {
+    Bonjour: jest.fn().mockImplementation(() => ({
+      publish: jest.fn(),
+      unpublishAll: jest.fn(),
+      destroy: jest.fn(),
+    })),
+  };
+});
+
+
+
 describe("Core", () => {
-    const mdnsMock = mDNS as jest.MockedClass<any>;
-    const bonjourMock = Bonjour as jest.MockedClass<any>;
-    const hostsList: string[] = [];
+  let mdns: mDNS.MulticastDNS;
+  let myEvent: EventEmitter;
 
-    beforeAll(done => {
-        done();
+  let bonjour: any;
+  let logger: any;
+  let error: any;
+  let hostnames: string[];
+  myEvent = new EventEmitter();
+  mdns = mDNS();
+  bonjour = new Bonjour(); // Instantiate Bonjour from the mock
+  logger = {
+    state: {
+      isEnabled: false,
+    },
+    info: jest.fn(),
+  };
+  error = null;
+  hostnames = ['example'];
+  const core = new Core(hostnames, undefined, undefined, logger, mdns, myEvent, bonjour);
+  const hostsList: string[] = [];
+
+  beforeAll(done => {
+    done();
+  });
+
+  afterAll(done => {
+    done();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("should be initialized", () => {
+    expect(() => {
+      return new Core(['mock']);
+    }).not.toThrowError();
+  });
+
+  it("should throw an error when hostnames are not provided", () => {
+    const core = new Core(hostsList);
+    expect(() => (core as any).__getHosts()).toThrowError(`Provide hostnames or path to hostnames! Report this error ${NPM_URL}`);
+  });
+
+  describe('listen', () => {
+    it('should call mdns.on and log a message "Looking for hostnames..."', () => {
+      const mdnsOnMock = jest.spyOn(mdns, 'on').mockImplementation((event, callback: any): any => {
+        if (event === 'response') {
+          callback({ answers: [] }); // call the callback with a dummy response object
+        }
+      });
+      core.listen();
+      expect(logger.info).toHaveBeenCalledWith('Looking for hostnames...', hostnames);
+      expect(mdnsOnMock.mock.calls[0][0]).toEqual('response');
+    });
+    it('should not call mdns.on and log a message "Looking for hostnames..."', () => {
+      (core as any).disableListener = true;
+      core.listen();
+      expect(logger.info).toHaveBeenCalledWith('Listener is disabled');
+      expect(mdns.on).not.toBeCalledWith();
+    });
+    // Add more test cases as needed
+  });
+  describe('stop function', () => {
+    it("should call mdns.removeAllListener", () => {
+      core.stop();
+      expect(mdns.removeAllListeners).toBeCalledWith();
+      expect(myEvent.removeAllListeners).toBeCalledWith();
     });
 
-    afterAll(done => {
-        done();
-    });
-
-    it("should be initialized", () => {
-        expect(() => {
-            return new Core(['mock']);
-        }).not.toThrowError();
-    });
-
-    it("should throw an error when hostnames are not provided", () => {
-        const core = new Core(hostsList);
-        expect(() => (core as any).__getHosts()).toThrowError(`Provide hostnames or path to hostnames! Report this error ${NPM_URL}`);
-    });
-
-    describe('listen', () => {
-        let myEvent: EventEmitter;
-        let mdns: any;
-        let bonjour: any;
-        let logger: any;
-        let error: any;
-        let hostnames: string[];
-        let core: Core;
-
-        beforeEach(() => {
-            myEvent = new EventEmitter();
-            mdns = mdnsMock();
-            bonjour = new Bonjour(); // Instantiate Bonjour from the mock
-            logger = {
-                state: {
-                    isEnabled: false,
-                },
-                info: jest.fn(),
-            };
-            error = null;
-            hostnames = ['example'];
-            core = new Core(hostnames, undefined, undefined, logger, mdns, myEvent, bonjour);
-        });
-
-        afterEach(() => {
-            jest.resetAllMocks();
-        });
-
-        it('should call mdns.on and log a message "Looking for hostnames..."', () => {
-            const mdnsOnMock = jest.spyOn(mdns, 'on').mockImplementation((event, callback: any) => {
-                if (event === 'response') {
-                    callback({ answers: [] }); // call the callback with a dummy response object
-                }
-            });
-            core.listen();
-            expect(logger.info).toHaveBeenCalledWith('Looking for hostnames...', hostnames);
-            expect(mdnsOnMock.mock.calls[0][0]).toEqual('response');
-        });
-
-        // Add more test cases as needed
-    });
+  });
 });

--- a/src/__test__/Core.test.ts
+++ b/src/__test__/Core.test.ts
@@ -1,54 +1,60 @@
-import {expect, jest, describe,beforeAll,afterAll,it,beforeEach,afterEach} from '@jest/globals';
+import { expect, jest, describe, beforeAll, afterAll, it, beforeEach, afterEach } from '@jest/globals';
 import { Core } from "@mdns-listener/Core";
 import { NPM_URL } from "@mdns-listener/types";
 import { EventEmitter } from "stream";
 
-
 jest.mock('multicast-dns', () => {
     return jest.fn(() => {
-      return {
-        on: jest.fn(),
-        query: jest.fn(),
-        destroy: jest.fn(),
-        emit: jest.fn(),
-      }
+        return {
+            on: jest.fn(),
+            query: jest.fn(),
+            destroy: jest.fn(),
+            emit: jest.fn(),
+        }
     });
-  });
-jest.mock('bonjour', () => {
-    return jest.fn(() => {
-      return {
-        
-      }
-    });
-  });
+});
+
+jest.mock('bonjour-service', () => {
+    return {
+        Bonjour: jest.fn().mockImplementation(() => ({
+            publish: jest.fn(),
+            unpublishAll: jest.fn(),
+            destroy: jest.fn(),
+        })),
+    };
+});
+
 import mDNS from 'multicast-dns';
-import bonjour from 'bonjour';
+import { Bonjour } from 'bonjour-service';
 
 describe("Core", () => {
     const mdnsMock = mDNS as jest.MockedClass<any>;
-    const bonjourMock = bonjour as jest.MockedClass<any>;
+    const bonjourMock = Bonjour as jest.MockedClass<any>;
     const hostsList: string[] = [];
-    
+
     beforeAll(done => {
         done();
     });
+
     afterAll(done => {
         done();
     });
+
     it("should be initialized", () => {
         expect(() => {
             return new Core(['mock']);
         }).not.toThrowError();
     });
+
     it("should throw an error when hostnames are not provided", () => {
         const core = new Core(hostsList);
-        expect(() => (core as any).__getHosts()).toThrowError(`Provide hostnames or path to hostnames ! Report this error ${NPM_URL}`);
+        expect(() => (core as any).__getHosts()).toThrowError(`Provide hostnames or path to hostnames! Report this error ${NPM_URL}`);
     });
 
     describe('listen', () => {
         let myEvent: EventEmitter;
         let mdns: any;
-        let bonjour:any;
+        let bonjour: any;
         let logger: any;
         let error: any;
         let hostnames: string[];
@@ -57,7 +63,7 @@ describe("Core", () => {
         beforeEach(() => {
             myEvent = new EventEmitter();
             mdns = mdnsMock();
-            bonjour  = bonjourMock();
+            bonjour = bonjourMock.Bonjour(); // Instantiate Bonjour from the mock
             logger = {
                 state: {
                     isEnabled: false,
@@ -66,7 +72,7 @@ describe("Core", () => {
             };
             error = null;
             hostnames = ['example'];
-            core = new Core(hostnames, undefined, undefined, logger, mdns, myEvent,bonjour);
+            core = new Core(hostnames, undefined, undefined, logger, mdns, myEvent, bonjour);
         });
 
         afterEach(() => {
@@ -74,17 +80,16 @@ describe("Core", () => {
         });
 
         it('should call mdns.on and log a message "Looking for hostnames..."', () => {
-            
-            const mdnsOnMock = jest.spyOn(mdns, 'on').mockImplementation((event, callback:any) => {
-              if (event === 'response') {
-                callback({ answers: [] }); // call the callback with a dummy response object
-                
-              }
+            const mdnsOnMock = jest.spyOn(mdns, 'on').mockImplementation((event, callback: any) => {
+                if (event === 'response') {
+                    callback({ answers: [] }); // call the callback with a dummy response object
+                }
             });
             core.listen();
             expect(logger.info).toHaveBeenCalledWith('Looking for hostnames...', hostnames);
             expect(mdnsOnMock.mock.calls[0][0]).toEqual('response');
-          });
-        
+        });
+
+        // Add more test cases as needed
     });
 });

--- a/src/__test__/Core.test.ts
+++ b/src/__test__/Core.test.ts
@@ -63,7 +63,7 @@ describe("Core", () => {
         beforeEach(() => {
             myEvent = new EventEmitter();
             mdns = mdnsMock();
-            bonjour = bonjourMock.Bonjour(); // Instantiate Bonjour from the mock
+            bonjour = new Bonjour(); // Instantiate Bonjour from the mock
             logger = {
                 state: {
                     isEnabled: false,


### PR DESCRIPTION
- Uninstall bonjour and use bonjour-service instead since the old package is not maintained and have too much issues that are unlikely to be resolved.
- increase jest tests coverage