### PR TITLE
feat: remove all production dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # mDNS Listener Advanced
 
-[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/aminekun90/mdns_listener_advanced/graphs/commit-activity) [![version number](https://img.shields.io/npm/v/mdns-listener-advanced?color=green&label=version)](https://github.com/aminekun90/mdns_listener_advanced/releases) [![Actions Status](https://github.com/aminekun90/mdns_listener_advanced/workflows/Test/badge.svg)](https://github.com/aminekun90/mdns_listener_advanced/actions) [![License](https://img.shields.io/github/license/aminekun90/mdns_listener_advanced)](https://github.com/aminekun90/mdns_listener_advanced/blob/master/LICENSE) ![node-current](https://img.shields.io/node/v/mdns-listener-advanced) [![Socket Badge](https://socket.dev/api/badge/npm/package/mdns-listener-advanced)](https://socket.dev/npm/package/mdns-listener-advanced) [![NPM](https://img.shields.io/badge/NPM-%23CB3837.svg?style=for-the-badge&logo=npm&logoColor=white)](https://www.npmjs.com/package/mdns-listener-advanced)
+[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/aminekun90/mdns_listener_advanced/graphs/commit-activity) [![version number](https://img.shields.io/npm/v/mdns-listener-advanced?color=green&label=version)](https://github.com/aminekun90/mdns_listener_advanced/releases)
+[![Actions Status](https://github.com/aminekun90/mdns_listener_advanced/workflows/Test/badge.svg)](https://github.com/aminekun90/mdns_listener_advanced/actions)
+[![License](https://img.shields.io/github/license/aminekun90/mdns_listener_advanced)](https://github.com/aminekun90/mdns_listener_advanced/blob/master/LICENSE)
+![node-current](https://img.shields.io/node/v/mdns-listener-advanced)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/mdns-listener-advanced)](https://socket.dev/npm/package/mdns-listener-advanced)
+[![NPM](https://img.shields.io/badge/NPM-%23CB3837.svg?style=for-the-badge&logo=npm&logoColor=white)](https://www.npmjs.com/package/mdns-listener-advanced)
 
 **:warning: Major update** Since version 3.0.0 this package is using a Typescript Implementation and it is fully tested on Mac OS Tahoe 26.1 and windows 11 and ubuntu 20.04
 If you have any issue feel free to [open an issue here](https://github.com/aminekun90/mdns_listener_advanced/issues)

--- a/__tests__/Core.test.ts
+++ b/__tests__/Core.test.ts
@@ -4,6 +4,7 @@ import { EmittedEvent } from "@/types.js";
 import * as dgram from "node:dgram";
 import * as fs from "node:fs";
 import * as os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 // --- Mocks ---
@@ -127,14 +128,14 @@ describe("Core", () => {
     );
   });
 
-  it("should fallback to OS homedir if no hosts provided", () => {
-    vi.mocked(fs.existsSync).mockImplementation((path) => path === "/home/testuser/.mdns-hosts");
+  it("should fallback to OS homedir if no hosts provided", async () => {
+    const expectedPath = path.join("/home/testuser", ".mdns-hosts");
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === expectedPath);
     vi.mocked(fs.readFileSync).mockReturnValue("home-host");
-
     const autoCore = new Core([], null, undefined, loggerMock);
-    autoCore.listen();
-
-    expect(fs.existsSync).toHaveBeenCalledWith("/home/testuser/.mdns-hosts");
+    const emitter = autoCore.listen();
+    emitter.on("error", () => { });
+    expect(fs.existsSync).toHaveBeenCalledWith(expectedPath);
     expect(loggerMock.info).toHaveBeenCalledWith(
       "Looking for hostnames...",
       ["home-host"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdns-listener-advanced",
-  "version": "3.3.7",
+  "version": "3.4.0",
   "description": "Advanced mDNS listener — discover and publish .local hostnames easily.",
   "author": "aminekun90",
   "license": "MIT",
@@ -42,12 +42,7 @@
     "prepare": "husky",
     "release": "yarn clean && yarn build && yarn test"
   },
-  "dependencies": {
-    "bonjour-service": "^1.3.0",
-    "multicast-dns": "^7.2.5",
-    "tslog": "^4.10.2",
-    "uuid": "^13.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -1,13 +1,15 @@
 // src/Core.ts
-import { Bonjour, ServiceConfig } from "bonjour-service";
-import multicastDns, { ResponsePacket } from "multicast-dns";
+import { randomUUID } from "node:crypto";
+import dgram from "node:dgram";
 import { EventEmitter } from "node:events";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir, networkInterfaces } from "node:os";
 import { join } from "node:path";
-import { Logger } from "tslog";
-import { v4 as uuidv4 } from "uuid";
-import { Device, DeviceBuffer, EmittedEvent, NPM_URL, Options } from "./types.js";
+import { MDNS_IP, MDNS_PORT, NPM_URL } from "./const.js"; // Ensure this matches your file name (constants.js or const.js)
+import { DNSBuffer } from "./protocol/DNSBuffer.js";
+import { Device, DeviceBuffer, EmittedEvent, Options } from "./types.js";
+import { SimpleLogger } from "./utils/Logger.js";
+import { parseTxtRecord } from "./utils/parsers.js";
 
 export class Core {
   private hostnames: string[];
@@ -17,19 +19,15 @@ export class Core {
   private disablePublisher: boolean;
   private error = false;
 
-  private readonly mdnsInstance: ReturnType<typeof multicastDns>;
-  private readonly publisher: Bonjour;
+  private readonly socket: dgram.Socket;
   private readonly myEvent: EventEmitter;
-  private readonly logger: Logger<any>;
+  private readonly logger: SimpleLogger;
 
   constructor(
     hostsList?: string[] | null,
     mdnsHostsPath?: string | null,
     options?: Options,
-    logger?: Logger<any>,
-    mdnsInstance?: ReturnType<typeof multicastDns>,
-    myEvent?: EventEmitter,
-    publisher?: Bonjour,
+    logger?: any,
   ) {
     this.hostnames = hostsList ?? [];
     this.mdnsHostsFile = mdnsHostsPath ?? undefined;
@@ -37,10 +35,17 @@ export class Core {
     this.disableListener = !!options?.disableListener;
     this.disablePublisher = !!options?.disablePublisher;
 
-    this.logger = logger ?? new Logger({ name: "MDNS ADVANCED" });
-    this.mdnsInstance = mdnsInstance ?? multicastDns();
-    this.myEvent = myEvent ?? new EventEmitter();
-    this.publisher = publisher ?? new Bonjour();
+    this.logger = logger ?? new SimpleLogger({ name: "MDNS ADVANCED" });
+    this.myEvent = new EventEmitter();
+
+    this.socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+
+    this.socket.on('error', (err) => {
+      this.logger.error("Socket Error", err);
+      this.error = true;
+    });
+
+    this.socket.on('message', (msg) => this.handleSocketMessage(msg));
   }
 
   private debug(...args: unknown[]) {
@@ -48,12 +53,15 @@ export class Core {
       this.logger.debug(...(args as [unknown, ...unknown[]]));
     }
   }
+
   public setDisableListener(value: boolean): void {
     this.disableListener = value;
   }
+
   public setDisablePublisher(value: boolean): void {
     this.disablePublisher = value;
   }
+
   private __initListener(): void {
     try {
       const hostsRaw = this.__getHosts();
@@ -79,14 +87,12 @@ export class Core {
       return this.hostnames.join("\n");
     }
 
-
     const defaultFile = join(homedir(), '.mdns-hosts');
 
     if (existsSync(defaultFile)) {
       this.mdnsHostsFile = defaultFile;
       return readFileSync(defaultFile, { encoding: "utf-8" });
     }
-
 
     this.logger.warn("Hostnames or path to hostnames is not provided, listening to a host is compromised!");
     throw new Error(`Provide hostnames or path to hostnames! Report this error ${NPM_URL}`);
@@ -108,106 +114,125 @@ export class Core {
 
   public publish(name: string) {
     if (this.disablePublisher) {
-      this.logger.info(
-        "Publisher is disabled unset 'Options.disablePublisher' or set it to 'false' to enable hosts publication !",
-      );
+      this.logger.info("Publisher is disabled.");
       return;
     }
-    const options: ServiceConfig = {
-      port: 3000,
-      name,
-      type: "TXT",
-      txt: {
-        uuid: `"${uuidv4()}"`,
-        ipv4: JSON.stringify(this.getLocalIpAddress() ?? ""),
-      },
-    };
-    const bonjourService = this.publisher.publish(options);
-    this.logger.info("A hostname has been published with options", options);
-    this.debug(bonjourService);
-    return bonjourService;
-  }
 
-  public unpublishAll(): void {
-    try {
-      this.publisher.unpublishAll();
-      this.logger.info("All hostnames have been unpublished");
-    } catch (err) {
-      this.debug("unpublishAll error", err);
+    const ip = this.getLocalIpAddress();
+    if (!ip) {
+      this.logger.warn("Could not find local IP");
+      return;
     }
+
+    const txtData = {
+      uuid: `"${randomUUID()}"`,
+      ipv4: JSON.stringify(ip),
+    };
+
+    const packet = DNSBuffer.createResponse(name, ip, txtData);
+
+    this.socket.send(packet, 0, packet.length, MDNS_PORT, MDNS_IP, (err) => {
+      if (err) this.logger.error("Failed to publish", err);
+      else this.logger.info("Published hostname:", name, txtData);
+    });
   }
 
   public listen(): EventEmitter {
-    if (this.disableListener) {
-      this.logger.info("Listener is disabled");
-      return this.myEvent;
-    }
+    if (this.disableListener) return this.myEvent;
 
     this.__initListener();
     if (this.error) {
-      const errorMessage = `An error occurred while trying to listen to mdns! Report this error ${NPM_URL}`;
+      const errorMessage = `Error in MDNS listener! Report: ${NPM_URL}`;
       process.nextTick(() => this.myEvent.emit(EmittedEvent.ERROR, new Error(errorMessage)));
       return this.myEvent;
     }
-    this.logger.info("Looking for hostnames...", this.hostnames);
 
-    this.mdnsInstance.on(EmittedEvent.RESPONSE, this.handleResponse.bind(this));
+    try {
+      this.socket.bind(MDNS_PORT, () => {
+        try {
+          this.socket.addMembership(MDNS_IP);
+          this.socket.setMulticastLoopback(true);
+          this.logger.info("Looking for hostnames...", this.hostnames);
+        } catch (e) {
+          this.logger.warn("Failed to add membership", e);
+        }
+      });
+    } catch (e) {
+      const errorMessage = `Failed to bind socket! Report: ${NPM_URL}`;
+      this.logger.error(errorMessage, e);
+    }
+
     return this.myEvent;
   }
 
-  private handleBufferData(dataBuffer: Buffer): { [key: string]: string } {
-    const str = dataBuffer.toString("utf8");
-    const props: { [key: string]: string } = {};
-    const regex = /([^=\s]+)=("((?:\\.|[^"\\])*)"|[^\s"]+)/g;
-    let match: RegExpExecArray | null;
+  private handleSocketMessage(msg: Buffer) {
+    try {
+      const parser = new DNSBuffer(msg);
 
-    while ((match = regex.exec(str)) !== null) {
-      const key = match[1];
-      // if group 3 exists it's the inner quoted capture
-      let value = match[3] ?? match[2];
-      value = value.replaceAll(String.raw`\"`, '"');
-      // strip surrounding quotes if still present
-      if (value.startsWith('"') && value.endsWith('"')) {
-        value = value.slice(1, -1);
+      // --- FIX: Read the FULL 12-byte Header ---
+      parser.readUInt16(); // ID
+      parser.readUInt16(); // Flags
+      const qdCount = parser.readUInt16(); // Questions Count
+      const anCount = parser.readUInt16(); // Answers Count
+      parser.readUInt16(); // NS Count (Authority)  <-- THIS WAS MISSING
+      parser.readUInt16(); // AR Count (Additional) <-- THIS WAS MISSING
+      // -----------------------------------------
+
+      // Skip Questions
+      for (let i = 0; i < qdCount; i++) {
+        parser.readName();
+        parser.readUInt16(); // Type
+        parser.readUInt16(); // Class
       }
-      props[key] = value;
+
+      // Read Answers
+      const answers: DeviceBuffer[] = [];
+      for (let i = 0; i < anCount; i++) {
+        if (parser.isDone) break;
+        answers.push(parser.readAnswer());
+      }
+
+      if (answers.length > 0) {
+        this.handleResponse({ answers } as any);
+      }
+    } catch (e) {
+      this.logger.error("Failed to handle socket message", e);
     }
-    return props;
   }
 
-  private handleResponse(response: { answers: Array<DeviceBuffer> } | ResponsePacket): void {
+  private handleResponse(response: { answers: Array<DeviceBuffer> }): void {
     const findHosts: Array<Device> = [];
+
+    if (!response.answers?.length) return;
+
     this.debug("RESPONSE:", response);
     this.myEvent.emit(EmittedEvent.RAW_RESPONSE, response);
 
-    const answers = Array.isArray((response as any).answers) ? (response as any).answers : [];
-
     for (const hostname of this.hostnames) {
-      for (const a of answers) {
-        if (a.data && Array.isArray(a.data) && a?.name?.includes(hostname)) {
+      for (const a of response.answers) {
+        if (a.name && a.name.includes(hostname) && a.type === 16 && Array.isArray(a.data)) {
+          const combinedBuffer = Buffer.concat(a.data);
+          // Uses the imported Utility function
           findHosts.push({
             name: a.name,
-            type: a.type,
-            data: this.handleBufferData(Buffer.concat((a.data as Buffer[]).map((d: any) => Buffer.from(d)))),
+            type: 'TXT',
+            data: parseTxtRecord(combinedBuffer),
           });
         }
       }
+    }
 
-      if (findHosts.length) {
-        this.myEvent.emit(EmittedEvent.RESPONSE, findHosts);
-      }
+    if (findHosts.length) {
+      this.myEvent.emit(EmittedEvent.RESPONSE, findHosts);
     }
   }
+
+  public stop() {
+    this.socket.close();
+    this.myEvent.removeAllListeners();
+  }
+
   public info(...args: any[]): void {
     this.logger.info(...args);
-  }
-  public stop(): void {
-    this.logger.info("Stopping mdns listener...");
-    try {
-      if (this.mdnsInstance?.removeAllListeners) this.mdnsInstance.removeAllListeners();
-      if (this.myEvent?.removeAllListeners) this.myEvent.removeAllListeners();
-    } catch (err) {
-      this.debug("stop error", err);
-    }
   }
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,0 +1,3 @@
+export const MDNS_IP = '224.0.0.251';
+export const MDNS_PORT = 5353;
+export const NPM_URL = "https://www.npmjs.com/package/mdns-listener-advanced";

--- a/src/protocol/DNSBuffer.ts
+++ b/src/protocol/DNSBuffer.ts
@@ -1,0 +1,138 @@
+export class DNSBuffer {
+    private readonly buffer: Buffer;
+    private offset: number = 0;
+
+    constructor(buffer?: Buffer) {
+        this.buffer = buffer || Buffer.alloc(0);
+    }
+
+    // --- Readers ---
+
+    readUInt16(): number {
+        const v = this.buffer.readUInt16BE(this.offset);
+        this.offset += 2;
+        return v;
+    }
+
+    readName(): string {
+        let name = '';
+        let jumped = false;
+        let jumpOffset = -1;
+        let currentOffset = this.offset;
+
+        while (true) {
+            if (currentOffset >= this.buffer.length) break;
+            const len = this.buffer.readUInt8(currentOffset);
+
+            // Handle Compression Pointer (0xC0)
+            if ((len & 0xC0) === 0xC0) {
+                if (!jumped) jumpOffset = currentOffset + 2;
+                const b2 = this.buffer.readUInt8(currentOffset + 1);
+                currentOffset = ((len & 0x3F) << 8) | b2;
+                jumped = true;
+                continue;
+            }
+
+            currentOffset++;
+            if (len === 0) break;
+            if (name.length > 0) name += '.';
+            name += this.buffer.toString('utf8', currentOffset, currentOffset + len);
+            currentOffset += len;
+        }
+
+        this.offset = jumped ? jumpOffset : currentOffset;
+        return name;
+    }
+
+    readAnswer() {
+        const name = this.readName();
+        const type = this.readUInt16();
+        const cls = this.readUInt16();
+        const ttl = this.buffer.readUInt32BE(this.offset);
+        this.offset += 4;
+        const len = this.readUInt16();
+
+        let data: any = null;
+
+        if (type === 16) { // TXT
+            // Return raw buffer array wrapper to match legacy structure expectation
+            data = [this.buffer.subarray(this.offset, this.offset + len)];
+        } else if (type === 1) { // A (IPv4)
+            data = this.buffer.subarray(this.offset, this.offset + len).join('.');
+        }
+
+        this.offset += len;
+        return { name, type, class: cls, ttl, data };
+    }
+
+    get isDone() { return this.offset >= this.buffer.length; }
+
+    // --- Writers ---
+
+    static createResponse(name: string, ip: string, txtData: { [key: string]: string }): Buffer {
+        const buffers: Buffer[] = [];
+
+        // --- 1. DNS Header ---
+        const header = Buffer.alloc(12);
+        header.writeUInt16BE(0, 0);       // ID (0)
+        header.writeUInt16BE(0x8400, 2);  // Flags (Response + Authoritative)
+        header.writeUInt16BE(0, 4);       // QDCOUNT (0 Questions)
+        header.writeUInt16BE(2, 6);       // ANCOUNT (2 Answers)
+        header.writeUInt16BE(0, 8);       // NSCOUNT
+        header.writeUInt16BE(0, 10);      // ARCOUNT
+
+        buffers.push(header);
+
+        // --- 2. Answer 1: A Record (IPv4) ---
+        const aHeader = Buffer.alloc(10);
+        aHeader.writeUInt16BE(1, 0);    // Type A
+        aHeader.writeUInt16BE(1, 2);    // Class IN
+        aHeader.writeUInt32BE(120, 4);  // TTL
+        aHeader.writeUInt16BE(4, 8);    // Data Length (4 bytes)
+
+        // FIX: Push Name, Header, and IP in one go
+        buffers.push(
+            this.encodeName(name),
+            aHeader,
+            Buffer.from(ip.split('.').map(Number))
+        );
+
+        // --- 3. Answer 2: TXT Record ---
+        const txtParts: Buffer[] = [];
+        for (const [k, v] of Object.entries(txtData)) {
+            const buf = Buffer.from(`${k}=${v}`);
+            const len = Buffer.alloc(1);
+            len.writeUInt8(buf.length);
+            txtParts.push(len, buf);
+        }
+        const fullTxt = Buffer.concat(txtParts);
+
+        const txtHeader = Buffer.alloc(10);
+        txtHeader.writeUInt16BE(16, 0); // Type TXT
+        txtHeader.writeUInt16BE(1, 2);  // Class IN
+        txtHeader.writeUInt32BE(120, 4); // TTL
+        txtHeader.writeUInt16BE(fullTxt.length, 8); // Data Length
+
+        // FIX: Push Name, Header, and TXT Data in one go
+        buffers.push(
+            this.encodeName(name),
+            txtHeader,
+            fullTxt
+        );
+
+        return Buffer.concat(buffers);
+    }
+
+    static encodeName(name: string): Buffer {
+        const parts = name.split('.');
+        const buf = Buffer.alloc(name.length + 2);
+        let offset = 0;
+        for (const part of parts) {
+            buf.writeUInt8(part.length, offset++);
+            buf.write(part, offset, 'utf8');
+            offset += part.length;
+        }
+        buf.writeUInt8(0, offset);
+        return buf.subarray(0, offset + 1);
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,18 +3,13 @@ export interface Options {
   disableListener?: boolean;
   disablePublisher?: boolean;
 }
-export const NPM_URL = "https://www.npmjs.com/package/mdns-listener-advanced";
 
 export type Device = {
   name: string;
   type: string;
   data: DeviceData | { [key: string]: string };
 };
-export type DeviceBuffer = {
-  name: string;
-  type: string;
-  data: Buffer;
-};
+export type DeviceBuffer = { name: string; type: number; class: number; ttl: number; data: any; };
 export type DeviceData = {
   uuid: string;
   ipv4: string;

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,0 +1,44 @@
+
+export class SimpleLogger {
+    private readonly name: string;
+    private readonly useColor: boolean;
+
+    // ANSI Color Codes
+    private static readonly RESET = "\x1b[0m";
+    private static readonly RED = "\x1b[31m";
+    private static readonly GREEN = "\x1b[32m";
+    private static readonly YELLOW = "\x1b[33m";
+    private static readonly BLUE = "\x1b[34m";
+    private static readonly MAGENTA = "\x1b[35m";
+    private static readonly CYAN = "\x1b[36m";
+
+    constructor(options: { name: string }) {
+        this.name = options.name;
+        // Only enable colors if we are in a Terminal (TTY) and not explicitly disabled
+        this.useColor = process.stdout.isTTY && !process.env.NO_COLOR;
+    }
+
+    private colorize(color: string, text: string): string {
+        return this.useColor ? `${color}${text}${SimpleLogger.RESET}` : text;
+    }
+
+    info(...args: any[]) {
+        const prefix = this.colorize(SimpleLogger.GREEN, `[${this.name}] INFO:`);
+        console.info(prefix, ...args);
+    }
+
+    warn(...args: any[]) {
+        const prefix = this.colorize(SimpleLogger.YELLOW, `[${this.name}] WARN:`);
+        console.warn(prefix, ...args);
+    }
+
+    debug(...args: any[]) {
+        const prefix = this.colorize(SimpleLogger.MAGENTA, `[${this.name}] DEBUG:`);
+        console.debug(prefix, ...args);
+    }
+
+    error(...args: any[]) {
+        const prefix = this.colorize(SimpleLogger.RED, `[${this.name}] ERROR:`);
+        console.error(prefix, ...args);
+    }
+}

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -1,0 +1,34 @@
+/**
+ * Parses a TXT record buffer (key=value) strings
+ */
+export function parseTxtRecord(buffer: Buffer): { [key: string]: string } {
+    const result: { [key: string]: string } = {};
+    let offset = 0;
+
+    // Iterate over the buffer using the Length-Prefixed format: [Len][String][Len][String]...
+    while (offset < buffer.length) {
+        // 1. Read the length of the next string
+        const len = buffer.readUInt8(offset);
+        offset++;
+
+        // Safety check: prevent reading past end of buffer
+        if (offset + len > buffer.length) break;
+
+        // 2. Read the string content
+        const str = buffer.toString('utf8', offset, offset + len);
+        offset += len;
+
+        const equalsIndex = str.indexOf('=');
+        if (equalsIndex === -1) {
+            result[str] = ''; // Key with empty value
+            continue;
+        }
+        const key = str.substring(0, equalsIndex);
+        const value = str.substring(equalsIndex + 1);
+
+        result[key] = value;
+
+    }
+
+    return result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -585,11 +585,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@leichtgewicht/ip-codec@^2.0.1":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
-  integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1106,14 +1101,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bonjour-service@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bonjour-service/-/bonjour-service-1.3.0.tgz#80d867430b5a0da64e82a8047fc1e355bdb71722"
-  integrity sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    multicast-dns "^7.2.5"
-
 brace-expansion@^1.1.7:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
@@ -1325,13 +1312,6 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
-
-dns-packet@^5.2.2:
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.6.1.tgz#ae888ad425a9d1478a0674256ab866de1012cf2f"
-  integrity sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==
-  dependencies:
-    "@leichtgewicht/ip-codec" "^2.0.1"
 
 dot-prop@^5.1.0:
   version "5.3.0"
@@ -2172,14 +2152,6 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-multicast-dns@^7.2.5:
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-7.2.5.tgz#77eb46057f4d7adbd16d9290fa7299f6fa64cced"
-  integrity sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==
-  dependencies:
-    dns-packet "^5.2.2"
-    thunky "^1.0.2"
-
 mz@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
@@ -2653,11 +2625,6 @@ thenify-all@^1.0.0:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-thunky@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
-  integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
-
 tinybench@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
@@ -2718,11 +2685,6 @@ tsconfck@^3.0.3:
   resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.1.6.tgz#da1f0b10d82237ac23422374b3fce1edb23c3ead"
   integrity sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==
 
-tslog@^4.10.2:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/tslog/-/tslog-4.10.2.tgz#45c870d7fe9558d59ce288eeb86ba49eaaf25e1e"
-  integrity sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==
-
 tsup@^8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/tsup/-/tsup-8.5.1.tgz#a9c7a875b93344bdf70600dedd78e70f88ec9a65"
@@ -2779,11 +2741,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-uuid@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.0.tgz#263dc341b19b4d755eb8fe36b78d95a6b65707e8"
-  integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==
 
 vite-tsconfig-paths@^5.1.4:
   version "5.1.4"


### PR DESCRIPTION
## Version v3.4.0

in order to have a better quality I aimed for coding the mdns/bonjour library from scratch, using node:dgram, in that logic I decided to remove all other dependencies in production.

- multicast-dns removed : using built in node:dgram
- bonjour removed
- tslog removed : implementing a simple logger
- uuid4 removed : using built in node:crypto

I hope this version enhance considerably the quality of the advanced mdns listener library.