### PR TITLE
feat: v3.4.4 enhance listen method

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,36 @@ import { Core } from "mdns-listener-advanced";
 const mdns = new Core();
 
 // Publish "MyCoolService.local"
-mdns.publish("MyCoolService", 30000); // 30000 ms = 30 seconds by default
+const customData = { hello: "world" };
+mdns.publish("MyCoolService",customData, 30000); // 30000 ms = 30 seconds by default
 
 // Your device is now visible to other mDNS scanners!
+
+// // 2. Start Listener
+const event = mdns.listen();
+
+// // --- HANDLERS ---
+
+event.on(EmittedEvent.RESPONSE, (found_hostnames: Device[]) => {
+  mdns.info("✅ Found TARGETED Host:", found_hostnames);
+});
+// stop
+```
+
+output:
+
+```shell
+[MDNS ADVANCED] INFO: ✅ Found TARGETED Host: [
+  {
+    name: 'MyDevice2',
+    type: 'TXT',
+    data: {
+      uuid: '"eec91263-de12-4525-ba08-81adad17cebb"',
+      ipv4: '"192.168.1.102"',
+      hello: 'world'
+    }
+  }
+]
 ```
 
 ### 4. Run the provided example
@@ -133,7 +160,7 @@ new Core(hostsList, mdnsHostsPath, options, logger)
 | Method                  | Description                                                                                                                    |
 |-------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | listen()                | Starts the UDP socket and joins the Multicast group. Returns the EventEmitter.                                                 |
-| publish(name, interval) | "Broadcasts an mDNS response, announcing name.local with your IP address. personalize the interval by default set to 30000ms." |
+| publish(name,data, interval) | "Broadcasts an mDNS response, announcing name.local with your IP address. add data to the TXT record, personalize the interval by default set to 30000ms." |
 | scan(serviceType)       | (New) Sends a query to the network. Default serviceType is _services._dns-sd._udp.local.                                       |
 | stop()                  | Closes the socket and removes all event listeners.                                                                             |
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ output:
     name: 'MyDevice2',
     type: 'TXT',
     data: {
-      uuid: '"eec91263-de12-4525-ba08-81adad17cebb"',
+      uuid: '"eec91263-de12-4525-ba08-81adad17-ceb3"',
       ipv4: '"192.168.1.102"',
       hello: 'world'
     }
@@ -199,7 +199,7 @@ If you do not provide a constructor list or this file, the listener will warn yo
 - Firewall: mDNS uses UDP port 5353. Ensure your firewall allows traffic on this port.
 - Docker: If running in Docker, you must use network_mode: "host" so the container can receive Multicast packets from the physical network.
 - Windows: You might need to allow Node.js through the Windows Defender Firewall on the first run.
-- MacOS + Docker limitations : running docker in host mode might not work on Mac-OS, since the container is not able to access the host network.
+- macOS + Docker limitations : running docker in host mode might not work on macOS, since the container is not able to access the host network.
 
 ## Support & Contribution
 

--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ new Core(hostsList, mdnsHostsPath, options, logger)
 
 ### Methods
 
-| Method                  | Description                                                                                                                    |
-|-------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| listen()                | Starts the UDP socket and joins the Multicast group. Returns the EventEmitter.                                                 |
+| Method                       | Description                                                                                                                                                |
+|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| listen(ref)                  | Starts the UDP socket and joins the Multicast group. Returns the EventEmitter, you can provide a string to listen for a specific host check example.ts.    |
 | publish(name,data, interval) | "Broadcasts an mDNS response, announcing name.local with your IP address. add data to the TXT record, personalize the interval by default set to 30000ms." |
-| scan(serviceType)       | (New) Sends a query to the network. Default serviceType is _services._dns-sd._udp.local.                                       |
-| stop()                  | Closes the socket and removes all event listeners.                                                                             |
+| scan(serviceType)            | (New) Sends a query to the network. Default serviceType is _services._dns-sd._udp.local.                                                                   |
+| stop()                       | Closes the socket and removes all event listeners.                                                                                                         |
 
 ### Events (EmittedEvent)
 

--- a/__tests__/Core.test.ts
+++ b/__tests__/Core.test.ts
@@ -1,3 +1,4 @@
+// src/Core.test.ts
 import { Core } from "@/Core.js";
 import { DNSBuffer } from "@/protocol/DNSBuffer.js";
 import { EmittedEvent } from "@/types.js";
@@ -41,6 +42,7 @@ const socketMock = {
   emit: vi.fn(),
   ref: vi.fn(),
   unref: vi.fn(),
+  address: vi.fn(() => ({ address: "0.0.0.0", port: 5353 })), // Added for initSocket check
 };
 
 vi.mock("node:dgram", () => {
@@ -96,188 +98,287 @@ describe("Core", () => {
     vi.restoreAllMocks();
   });
 
-  it("should initialize and create a UDP socket", () => {
-    expect(dgram.createSocket).toHaveBeenCalledWith({ type: "udp4", reuseAddr: true });
-    expect(socketMock.on).toHaveBeenCalledWith("error", expect.any(Function));
-    expect(socketMock.on).toHaveBeenCalledWith("message", expect.any(Function));
-  });
-
-  it("should enable debug logging when option is set", () => {
-    (core as any).debug("test message");
-    expect(loggerMock.debug).toHaveBeenCalledWith("test message");
-  });
-
-  it("should load hosts from explicit string array", () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    core.listen();
-    expect(loggerMock.info).toHaveBeenCalledWith(
-      "Looking for hostnames...",
-      expect.arrayContaining(["example-device"]),
-    );
-  });
-
-  it("should load hosts from file path", () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readFileSync).mockReturnValue("host-from-file");
-
-    const fileCore = new Core(null, "/custom/path", undefined, loggerMock);
-    fileCore.listen();
-
-    expect(fs.readFileSync).toHaveBeenCalledWith("/custom/path", { encoding: "utf-8" });
-    expect(loggerMock.info).toHaveBeenCalledWith("Looking for hostnames...", ["host-from-file"]);
-  });
-
-  it("should fallback to OS homedir if no hosts provided", async () => {
-    const expectedPath = path.join("/home/testuser", ".mdns-hosts");
-
-    vi.mocked(fs.existsSync).mockImplementation((p) => p === expectedPath);
-    vi.mocked(fs.readFileSync).mockReturnValue("home-host");
-
-    const autoCore = new Core([], null, undefined, loggerMock);
-
-    // Prevent unhandled error crash
-    const emitter = autoCore.listen();
-    emitter.on("error", () => {});
-
-    expect(fs.existsSync).toHaveBeenCalledWith(expectedPath);
-    expect(loggerMock.info).toHaveBeenCalledWith("Looking for hostnames...", ["home-host"]);
-  });
-
-  it("should throw error if no hosts found anywhere", async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const emptyCore = new Core([], null, undefined, loggerMock);
-    const eventSpy = vi.fn();
-
-    const emitter = emptyCore.listen();
-    emitter.on(EmittedEvent.ERROR, eventSpy);
-    // Safety net for string-based 'error'
-    emitter.on("error", () => {});
-
-    await new Promise(process.nextTick);
-
-    expect(eventSpy).toHaveBeenCalledWith(expect.any(Error));
-    expect(loggerMock.warn).toHaveBeenCalledWith(expect.stringMatching(/not provided/));
-  });
-
-  it("should bind socket and add membership on listen", () => {
-    core.listen();
-    expect(socketMock.bind).toHaveBeenCalledWith(5353, expect.any(Function));
-    expect(socketMock.addMembership).toHaveBeenCalledWith("224.0.0.251");
-    expect(socketMock.setMulticastLoopback).toHaveBeenCalledWith(true);
-  });
-
-  it("should emit error if socket binding fails", () => {
-    (socketMock.bind as Mock).mockImplementationOnce(() => {
-      throw new Error("Bind failed");
+  describe("Initialization & Config", () => {
+    it("should initialize and create a UDP socket", () => {
+      expect(dgram.createSocket).toHaveBeenCalledWith({
+        type: "udp4",
+        reuseAddr: true,
+      });
+      expect(socketMock.on).toHaveBeenCalledWith("error", expect.any(Function));
+      expect(socketMock.on).toHaveBeenCalledWith("message", expect.any(Function));
     });
 
-    core.listen();
-    expect(loggerMock.error).toHaveBeenCalledWith(
-      expect.stringContaining("Failed to bind"),
-      expect.any(Error),
-    );
-  });
+    it("should enable debug logging when option is set", () => {
+      (core as any).debug("test message");
+      expect(loggerMock.debug).toHaveBeenCalledWith("test message");
+    });
 
-  it("should parse a valid mDNS Response packet and emit event", () => {
-    const emitter = core.listen();
-    const eventSpy = vi.fn();
-    emitter.on(EmittedEvent.RESPONSE, eventSpy);
+    it("should load hosts from explicit string array", () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      core.listen();
+      expect(loggerMock.info).toHaveBeenCalledWith(
+        "Looking for hostnames...",
+        expect.arrayContaining(["example-device"]),
+      );
+    });
 
-    const targetHost = "example-device.local";
-    // NOTE: This packet places TXT records in the 'Additional' section.
-    // Core.ts must iterate over (anCount + nsCount + arCount) to find it.
-    const packet = DNSBuffer.createResponse(targetHost, "192.168.1.50", { "my-key": "my-value" });
+    it("should load hosts from file path", () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue("host-from-file");
 
-    const onMessage = socketHandlers["message"];
-    expect(onMessage).toBeDefined();
+      const fileCore = new Core(null, "/custom/path", undefined, loggerMock);
+      fileCore.listen();
 
-    onMessage(packet);
+      expect(fs.readFileSync).toHaveBeenCalledWith("/custom/path", {
+        encoding: "utf-8",
+      });
+      expect(loggerMock.info).toHaveBeenCalledWith("Looking for hostnames...", ["host-from-file"]);
+    });
 
-    expect(eventSpy).toHaveBeenCalledTimes(1);
+    it("should fallback to OS homedir if no hosts provided", async () => {
+      const expectedPath = path.join("/home/testuser", ".mdns-hosts");
 
-    const emittedData = eventSpy.mock.calls[0][0];
-    expect(emittedData).toHaveLength(1);
+      vi.mocked(fs.existsSync).mockImplementation((p) => p === expectedPath);
+      vi.mocked(fs.readFileSync).mockReturnValue("home-host");
 
-    expect(emittedData[0]).toMatchObject({
-      name: "example-device.local",
-      type: "TXT",
-      data: { "my-key": "my-value" },
+      const autoCore = new Core([], null, undefined, loggerMock);
+
+      // Prevent unhandled error crash
+      const emitter = autoCore.listen();
+      emitter.on("error", () => {});
+
+      expect(fs.existsSync).toHaveBeenCalledWith(expectedPath);
+      expect(loggerMock.info).toHaveBeenCalledWith("Looking for hostnames...", ["home-host"]);
+    });
+
+    it("should throw error if no hosts found anywhere", async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const emptyCore = new Core([], null, undefined, loggerMock);
+      const eventSpy = vi.fn();
+
+      const emitter = emptyCore.listen();
+      emitter.on(EmittedEvent.ERROR, eventSpy);
+      emitter.on("error", () => {}); // Safety net
+
+      await new Promise(process.nextTick);
+
+      expect(eventSpy).toHaveBeenCalledWith(expect.any(Error));
+      expect(loggerMock.warn).toHaveBeenCalledWith(expect.stringMatching(/not provided/));
     });
   });
 
-  it("should ignore packets that do not match the hostname list", () => {
-    const emitter = core.listen();
-    const eventSpy = vi.fn();
-    emitter.on(EmittedEvent.RESPONSE, eventSpy);
-
-    const packet = DNSBuffer.createResponse("other-device.local", "1.1.1.1", {});
-
-    socketHandlers["message"](packet);
-
-    expect(eventSpy).not.toHaveBeenCalled();
-  });
-
-  it("should handle Malformed/Garbage packets gracefully", () => {
-    core.listen();
-    const onMessage = socketHandlers["message"];
-    const garbage = Buffer.from([0x00, 0x01, 0xff]);
-
-    expect(() => onMessage(garbage)).not.toThrow();
-    // Assuming logger.warn for malformed packets based on latest Core.ts
-    expect(loggerMock.warn).toHaveBeenCalledWith("Failed to parse message", expect.anything());
-  });
-
-  it("should publish a hostname (send packet)", () => {
-    vi.mocked(os.networkInterfaces).mockReturnValue({
-      eth0: [
-        {
-          address: "192.168.1.100",
-          family: "IPv4",
-          internal: false,
-          mac: "",
-          netmask: "",
-          cidr: "",
-        },
-      ],
+  describe("Socket Lifecycle", () => {
+    it("should bind socket and add membership on listen", () => {
+      core.listen();
+      expect(socketMock.bind).toHaveBeenCalledWith(5353, expect.any(Function));
+      expect(socketMock.addMembership).toHaveBeenCalledWith("224.0.0.251");
+      expect(socketMock.setMulticastLoopback).toHaveBeenCalledWith(true);
     });
 
-    core.publish("my-service");
+    it("should emit error if socket binding fails", () => {
+      (socketMock.bind as Mock).mockImplementationOnce(() => {
+        throw new Error("Bind failed");
+      });
 
-    expect(socketMock.send).toHaveBeenCalledTimes(1);
+      core.listen();
+      expect(loggerMock.error).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to bind"),
+        expect.any(Error),
+      );
+    });
 
-    const [buffer, offset, length, port, ip] = (socketMock.send as Mock).mock.calls[0];
+    it("should NOT re-bind if already listening (Idempotency)", () => {
+      core.listen();
+      expect(socketMock.bind).toHaveBeenCalledTimes(1);
 
-    expect(offset).toBe(0);
-    expect(length).toBe(125);
+      core.listen();
+      expect(socketMock.bind).toHaveBeenCalledTimes(1); // Still 1
+    });
 
-    expect(buffer).toBeInstanceOf(Buffer);
-    expect(port).toBe(5353);
-    expect(ip).toBe("224.0.0.251");
+    it("should handle ERR_SOCKET_ALREADY_BOUND gracefully", () => {
+      // Simulate race condition error
+      (socketMock.bind as Mock).mockImplementationOnce(() => {
+        const err: any = new Error("Already bound");
+        err.code = "ERR_SOCKET_ALREADY_BOUND";
+        throw err;
+      });
+
+      core.listen();
+      // Should not emit error event
+      expect(loggerMock.error).not.toHaveBeenCalled();
+      // Should set listening to true
+      expect((core as any).isListening).toBe(true);
+    });
+
+    it("should allow dynamic hostnames via listen(ref)", () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      core.listen("dynamic-host-1\ndynamic-host-2");
+      expect(loggerMock.info).toHaveBeenCalledWith(
+        "Looking for hostnames...",
+        expect.arrayContaining(["dynamic-host-1", "dynamic-host-2"]),
+      );
+    });
   });
 
-  it("should not publish if disabled", () => {
-    core.setDisablePublisher(true);
-    core.publish("test");
-    expect(socketMock.send).not.toHaveBeenCalled();
-    expect(loggerMock.info).toHaveBeenCalledWith("Publisher is disabled.");
+  describe("Parsing & Responses", () => {
+    it("should parse a valid mDNS Response packet and emit event", () => {
+      const emitter = core.listen();
+      const eventSpy = vi.fn();
+      emitter.on(EmittedEvent.RESPONSE, eventSpy);
+
+      const targetHost = "example-device.local";
+      const packet = DNSBuffer.createResponse(targetHost, "192.168.1.50", {
+        "my-key": "my-value",
+      });
+
+      const onMessage = socketHandlers["message"];
+      expect(onMessage).toBeDefined();
+
+      onMessage(packet);
+
+      expect(eventSpy).toHaveBeenCalledTimes(1);
+      const emittedData = eventSpy.mock.calls[0][0];
+      expect(emittedData[0]).toMatchObject({
+        name: "example-device.local",
+        type: "TXT",
+        data: { "my-key": "my-value" },
+      });
+    });
+
+    it("should ignore packets that do not match the hostname list", () => {
+      const emitter = core.listen();
+      const eventSpy = vi.fn();
+      emitter.on(EmittedEvent.RESPONSE, eventSpy);
+      const packet = DNSBuffer.createResponse("other-device.local", "1.1.1.1", {});
+      socketHandlers["message"](packet);
+      expect(eventSpy).not.toHaveBeenCalled();
+    });
+
+    it("should handle Malformed packets gracefully", () => {
+      core.listen();
+      const onMessage = socketHandlers["message"];
+      const garbage = Buffer.from([0x00, 0x01, 0xff]);
+
+      expect(() => onMessage(garbage)).not.toThrow();
+      expect(loggerMock.warn).toHaveBeenCalledWith("Failed to parse message", expect.anything());
+    });
   });
 
-  it("should abort publish if no local IP found", () => {
-    vi.mocked(os.networkInterfaces).mockReturnValue({});
+  describe("Publishing (Heartbeat)", () => {
+    beforeEach(() => {
+      vi.mocked(os.networkInterfaces).mockReturnValue({
+        eth0: [
+          {
+            address: "192.168.1.100",
+            family: "IPv4",
+            internal: false,
+            mac: "",
+            netmask: "",
+            cidr: "",
+          },
+        ],
+      });
+      vi.useFakeTimers(); // Enable fake timers
+    });
 
-    core.publish("test");
-    expect(socketMock.send).not.toHaveBeenCalled();
-    expect(loggerMock.warn).toHaveBeenCalledWith("Could not find local IP during publish");
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should publish immediately once", () => {
+      core.publish("my-service", {}, 0); // 0 interval = one shot
+
+      expect(socketMock.send).toHaveBeenCalledTimes(1);
+      const [buffer, offset, length, port, ip] = (socketMock.send as Mock).mock.calls[0];
+      expect(buffer).toBeInstanceOf(Buffer);
+      expect(offset).toBe(0);
+      expect(port).toBe(5353);
+      expect(ip).toBe("224.0.0.251");
+      expect(length).toBeGreaterThan(0);
+    });
+
+    it("should publish repeatedly with interval", () => {
+      core.publish("my-heartbeat", {}, 1000); // 1s interval
+
+      // Immediate call
+      expect(socketMock.send).toHaveBeenCalledTimes(1);
+
+      // Advance 1s
+      vi.advanceTimersByTime(1000);
+      expect(socketMock.send).toHaveBeenCalledTimes(2);
+
+      // Advance another 1s
+      vi.advanceTimersByTime(1000);
+      expect(socketMock.send).toHaveBeenCalledTimes(3);
+    });
+
+    it("should not publish if disabled", () => {
+      core.setDisablePublisher(true);
+      core.publish("test");
+      expect(socketMock.send).not.toHaveBeenCalled();
+      expect(loggerMock.info).toHaveBeenCalledWith("Publisher is disabled.");
+    });
+
+    it("should abort publish if no local IP found", () => {
+      vi.mocked(os.networkInterfaces).mockReturnValue({});
+      core.publish("test");
+      expect(socketMock.send).not.toHaveBeenCalled();
+      expect(loggerMock.warn).toHaveBeenCalledWith("Could not find local IP during publish");
+    });
+
+    it("should clear timer on stop()", () => {
+      core.publish("my-heartbeat", {}, 1000);
+      expect(socketMock.send).toHaveBeenCalledTimes(1);
+
+      core.stop(); // Should clear interval
+
+      vi.advanceTimersByTime(2000);
+      expect(socketMock.send).toHaveBeenCalledTimes(1); // Still 1, no new calls
+    });
   });
 
-  it("should close socket and remove listeners on stop", () => {
-    const emitter = core.listen();
-    const spyRemove = vi.spyOn(emitter, "removeAllListeners");
+  describe("Discovery (Scan)", () => {
+    it("should send a PTR query packet when scan is called", () => {
+      core.listen();
+      core.scan("_googlecast._tcp.local");
 
-    core.stop();
+      expect(socketMock.send).toHaveBeenCalled();
+      // Check last call
+      const calls = (socketMock.send as Mock).mock.calls;
+      const lastCall: any = calls.at(-1); // scan calls send
+      const [buffer, , , port, ip] = lastCall;
 
-    expect(socketMock.close).toHaveBeenCalled();
-    expect(spyRemove).toHaveBeenCalled();
+      expect(port).toBe(5353);
+      expect(ip).toBe("224.0.0.251");
+      // Basic check that buffer is generated (DNSBuffer implementation dependent)
+      expect(buffer).toBeInstanceOf(Buffer);
+      expect(loggerMock.info).toHaveBeenCalledWith(expect.stringContaining("Scanning network for"));
+    });
+
+    it("should not scan if listener is disabled", () => {
+      core.setDisableListener(true);
+      core.scan();
+      expect(loggerMock.warn).toHaveBeenCalledWith(expect.stringContaining("Cannot scan"));
+    });
+
+    // Note: Testing reception of DISCOVERY events (PTR/SRV/A) strictly requires
+    // constructing binary DNS packets with those specific record types.
+    // Since we rely on the internal DNSBuffer to parse them, and creating
+    // complex binary mocks is brittle without the specific packet generator,
+    // we primarily verify the *sending* logic here.
+  });
+
+  describe("Cleanup", () => {
+    it("should close socket and remove listeners on stop", () => {
+      const emitter = core.listen();
+      const spyRemove = vi.spyOn(emitter, "removeAllListeners");
+
+      core.stop();
+
+      expect(socketMock.close).toHaveBeenCalled();
+      expect(spyRemove).toHaveBeenCalled();
+      expect((core as any).isListening).toBe(false);
+    });
   });
 });

--- a/__tests__/protocol/DNSBuffer.test.ts
+++ b/__tests__/protocol/DNSBuffer.test.ts
@@ -1,0 +1,231 @@
+import { DNSBuffer } from "@/protocol/DNSBuffer.js"; // Adjust path if needed
+import { describe, expect, it } from "vitest";
+
+describe("DNSBuffer", () => {
+  // --- Constructor & Basic properties ---
+  it("should initialize with an empty buffer if none provided", () => {
+    const dns = new DNSBuffer();
+    expect(dns.isDone).toBe(true);
+  });
+
+  it("should initialize with a provided buffer", () => {
+    const buf = Buffer.from([0x01]);
+    const dns = new DNSBuffer(buf);
+    expect(dns.isDone).toBe(false);
+  });
+
+  // --- Readers ---
+  describe("readUInt16", () => {
+    it("should read a 16-bit unsigned integer", () => {
+      // 0x0102 = 258
+      const buf = Buffer.from([0x01, 0x02]);
+      const dns = new DNSBuffer(buf);
+      expect(dns.readUInt16()).toBe(258);
+      expect(dns.isDone).toBe(true);
+    });
+  });
+
+  describe("readName", () => {
+    it("should read a simple domain name", () => {
+      // 3 'w' 'w' 'w' 6 'g' 'o' 'o' 'g' 'l' 'e' 3 'c' 'o' 'm' 0
+      const buf = DNSBuffer.encodeName("www.google.com");
+      const dns = new DNSBuffer(buf);
+      expect(dns.readName()).toBe("www.google.com");
+    });
+
+    it("should handle DNS compression pointers", () => {
+      // Construct a buffer with a pointer
+      // Offset 0: "google" (6 g o o g l e) + null (0)
+      // Offset 8: "www" (3 w w w) + Pointer to 0 (0xC0 0x00)
+
+      const part1 = Buffer.from([0x06, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x00]); // "google."
+      const part2 = Buffer.from([0x03, 0x77, 0x77, 0x77, 0xc0, 0x00]); // "www" -> pointer to 0
+
+      const buf = Buffer.concat([part1, part2]);
+      const dns = new DNSBuffer(buf);
+
+      // Read first name (google) to advance offset? No, we want to skip to offset 8 manually
+      // or just read two names.
+      // Let's read the first one "google"
+      expect(dns.readName()).toBe("google");
+
+      // Now read the second one "www.google" (which uses the pointer)
+      expect(dns.readName()).toBe("www.google");
+    });
+
+    it("should handle empty/root name", () => {
+      const buf = Buffer.from([0x00]);
+      const dns = new DNSBuffer(buf);
+      expect(dns.readName()).toBe("");
+    });
+  });
+
+  // --- readAnswer (The Complex Logic) ---
+  describe("readAnswer", () => {
+    it("should parse Type 1 (A Record / IPv4)", () => {
+      // Header + 4 bytes IP (192.168.1.1)
+      //   const header = createAnswerHeader(1, 4);
+      //   const ip = Buffer.from([192, 168, 1, 1]);
+
+      // We need a valid name at offset 0xC00C (12) for the parser to work?
+      // Actually readAnswer calls readName() first.
+      // Let's make it simpler: explicit simple name at start.
+
+      const name = DNSBuffer.encodeName("test.local");
+      const rest = Buffer.alloc(10); // Type(2) Class(2) TTL(4) Len(2)
+      rest.writeUInt16BE(1, 0); // Type A
+      rest.writeUInt16BE(1, 2); // Class
+      rest.writeUInt32BE(100, 4); // TTL
+      rest.writeUInt16BE(4, 8); // Len 4
+
+      const ipData = Buffer.from([10, 0, 0, 5]);
+
+      const buf = Buffer.concat([name, rest, ipData]);
+      const dns = new DNSBuffer(buf);
+
+      const ans = dns.readAnswer();
+      expect(ans.name).toBe("test.local");
+      expect(ans.type).toBe(1);
+      expect(ans.data).toBe("10.0.0.5");
+    });
+
+    it("should parse Type 16 (TXT Record)", () => {
+      const name = DNSBuffer.encodeName("txt.local");
+      const rest = Buffer.alloc(10);
+      rest.writeUInt16BE(16, 0); // Type TXT
+      rest.writeUInt16BE(1, 2); // Class
+      rest.writeUInt32BE(100, 4); // TTL
+
+      const txtContent = Buffer.from("hello=world");
+      rest.writeUInt16BE(txtContent.length, 8); // Len
+
+      const buf = Buffer.concat([name, rest, txtContent]);
+      const dns = new DNSBuffer(buf);
+
+      const ans = dns.readAnswer();
+      expect(ans.type).toBe(16);
+      expect(Array.isArray(ans.data)).toBe(true);
+      expect(ans.data[0].toString()).toBe("hello=world");
+    });
+
+    it("should parse Type 12 (PTR Record)", () => {
+      const name = DNSBuffer.encodeName("ptr.local");
+      const rest = Buffer.alloc(10);
+      rest.writeUInt16BE(12, 0); // Type PTR
+      rest.writeUInt16BE(1, 2);
+      rest.writeUInt32BE(100, 4);
+
+      const targetName = DNSBuffer.encodeName("target.local");
+      rest.writeUInt16BE(targetName.length, 8); // Len
+
+      const buf = Buffer.concat([name, rest, targetName]);
+      const dns = new DNSBuffer(buf);
+
+      const ans = dns.readAnswer();
+      expect(ans.type).toBe(12);
+      expect(ans.data).toBe("target.local");
+    });
+
+    it("should parse Type 33 (SRV Record)", () => {
+      const name = DNSBuffer.encodeName("srv.local");
+      const rest = Buffer.alloc(10);
+      rest.writeUInt16BE(33, 0); // Type SRV
+      rest.writeUInt16BE(1, 2);
+      rest.writeUInt32BE(100, 4);
+
+      const targetName = DNSBuffer.encodeName("target.local");
+      const srvData = Buffer.alloc(6);
+      srvData.writeUInt16BE(10, 0); // Priority
+      srvData.writeUInt16BE(20, 2); // Weight
+      srvData.writeUInt16BE(8080, 4); // Port
+
+      // Total Data Length = 6 + name length
+      rest.writeUInt16BE(6 + targetName.length, 8);
+
+      const buf = Buffer.concat([name, rest, srvData, targetName]);
+      const dns = new DNSBuffer(buf);
+
+      const ans = dns.readAnswer();
+      expect(ans.type).toBe(33);
+      expect(ans.data).toEqual({
+        priority: 10,
+        weight: 20,
+        port: 8080,
+        target: "target.local",
+      });
+    });
+
+    it("should safely skip Unknown Types", () => {
+      const name = DNSBuffer.encodeName("unknown.local");
+      const rest = Buffer.alloc(10);
+      rest.writeUInt16BE(999, 0); // Type 999 (Unknown)
+      rest.writeUInt16BE(1, 2);
+      rest.writeUInt32BE(100, 4);
+
+      const garbageData = Buffer.from([0xaa, 0xbb, 0xcc]);
+      rest.writeUInt16BE(garbageData.length, 8); // Len
+
+      const buf = Buffer.concat([name, rest, garbageData]);
+      const dns = new DNSBuffer(buf);
+
+      const ans = dns.readAnswer();
+      expect(ans.type).toBe(999);
+      expect(ans.data).toBe(null); // Unknown type returns null data
+      expect(dns.isDone).toBe(true); // Should have skipped garbage data
+    });
+  });
+
+  // --- Static Writers ---
+  describe("createQuery", () => {
+    it("should create a valid DNS Query packet", () => {
+      const buf = DNSBuffer.createQuery("test.local", 12);
+
+      // Header is 12 bytes
+      expect(buf.readUInt16BE(0)).toBe(0); // ID
+      expect(buf.readUInt16BE(2)).toBe(0); // Flags
+      expect(buf.readUInt16BE(4)).toBe(1); // QDCOUNT (1)
+
+      // Check Name (12 is offset of header)
+      // "test.local" -> 4test5local0
+      expect(buf.readUInt8(12)).toBe(4); // 'test' length
+
+      // Check Footer (Type + Class)
+      // Header(12) + Name(4+1+5+1+1 = 12) = 24 offset
+      const typeOffset = 12 + 12;
+      expect(buf.readUInt16BE(typeOffset)).toBe(12); // Type PTR
+      expect(buf.readUInt16BE(typeOffset + 2)).toBe(1); // Class IN
+    });
+  });
+
+  describe("createResponse", () => {
+    it("should create a valid DNS Response packet", () => {
+      const buf = DNSBuffer.createResponse("dev.local", "1.2.3.4", { key: "val" });
+
+      const dns = new DNSBuffer(buf);
+
+      // 1. Read Header
+      dns.readUInt16(); // ID
+      const flags = dns.readUInt16();
+      expect(flags).toBe(0x8400); // Response + Authoritative
+
+      dns.readUInt16(); // QD
+      const anCount = dns.readUInt16();
+      expect(anCount).toBe(2); // A + TXT
+
+      dns.readUInt16(); // NS
+      dns.readUInt16(); // AR
+
+      // 2. Read Answer 1 (A Record)
+      const ans1 = dns.readAnswer();
+      expect(ans1.name).toBe("dev.local");
+      expect(ans1.type).toBe(1);
+      expect(ans1.data).toBe("1.2.3.4");
+
+      // 3. Read Answer 2 (TXT Record)
+      const ans2 = dns.readAnswer();
+      expect(ans2.name).toBe("dev.local");
+      expect(ans2.type).toBe(16);
+      expect(ans2.data[0].toString()).toContain("key=val");
+    });
+  });
+});

--- a/__tests__/utils/Logger.test.ts
+++ b/__tests__/utils/Logger.test.ts
@@ -1,0 +1,88 @@
+import { SimpleLogger } from "@/utils/Logger.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("SimpleLogger", () => {
+  let consoleSpy: {
+    info: ReturnType<typeof vi.spyOn>;
+    warn: ReturnType<typeof vi.spyOn>;
+    debug: ReturnType<typeof vi.spyOn>;
+    error: ReturnType<typeof vi.spyOn>;
+  };
+
+  beforeEach(() => {
+    // Spy on console methods to verify output without printing to stdout
+    consoleSpy = {
+      info: vi.spyOn(console, "info").mockImplementation(() => {}),
+      warn: vi.spyOn(console, "warn").mockImplementation(() => {}),
+      debug: vi.spyOn(console, "debug").mockImplementation(() => {}),
+      error: vi.spyOn(console, "error").mockImplementation(() => {}),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Color Logic", () => {
+    it("should disable colors when noColor option is true", () => {
+      // Force TTY to true to ensure our option overrides it
+      process.stdout.isTTY = true;
+
+      const logger = new SimpleLogger({ name: "TEST", noColor: true });
+      logger.info("message");
+
+      // Expect Plain Text: "[TEST] INFO:"
+      expect(consoleSpy.info).toHaveBeenCalledWith("[TEST] INFO:", "message");
+    });
+
+    it("should enable colors when TTY is true and noColor is false", () => {
+      process.stdout.isTTY = true;
+
+      const logger = new SimpleLogger({ name: "TEST", noColor: false });
+      logger.info("message");
+
+      // Expect ANSI Codes: "\x1b[32m[TEST] INFO:\x1b[0m"
+      const callArgs = consoleSpy.info.mock.calls[0];
+      expect(callArgs[0]).toContain("\x1b[32m"); // Green color code
+      expect(callArgs[0]).toContain("[TEST] INFO:");
+      expect(callArgs[0]).toContain("\x1b[0m"); // Reset code
+    });
+
+    it("should disable colors automatically if not in TTY", () => {
+      // Simulate non-interactive terminal (e.g. CI pipe)
+      process.stdout.isTTY = undefined as unknown as boolean;
+
+      const logger = new SimpleLogger({ name: "TEST" });
+      logger.info("message");
+
+      // Expect Plain Text
+      expect(consoleSpy.info).toHaveBeenCalledWith("[TEST] INFO:", "message");
+    });
+  });
+
+  describe("Log Levels", () => {
+    // We use noColor: true here to simplify string matching assertions
+    const logger = new SimpleLogger({ name: "TEST", noColor: true });
+
+    it("should log info messages to console.info", () => {
+      logger.info("hello world", { foo: "bar" });
+      expect(consoleSpy.info).toHaveBeenCalledWith("[TEST] INFO:", "hello world", { foo: "bar" });
+    });
+
+    it("should log warning messages to console.warn", () => {
+      logger.warn("warning happened");
+      expect(consoleSpy.warn).toHaveBeenCalledWith("[TEST] WARN:", "warning happened");
+    });
+
+    it("should log debug messages to console.debug", () => {
+      logger.debug("debugging");
+      expect(consoleSpy.debug).toHaveBeenCalledWith("[TEST] DEBUG:", "debugging");
+    });
+
+    it("should log error messages to console.error", () => {
+      const err = new Error("oops");
+      logger.error("fatal error", err);
+      expect(consoleSpy.error).toHaveBeenCalledWith("[TEST] ERROR:", "fatal error", err);
+    });
+  });
+});

--- a/example.ts
+++ b/example.ts
@@ -35,7 +35,7 @@ event.on(EmittedEvent.ERROR, (error: Error) => {
 
 // --- GRACEFUL SHUTDOWN (Ctrl + C) ---
 process.on("SIGINT", () => {
-  mdns.info("\n🛑 Stopping mDNS Service...");
+  mdns.info("🛑 Stopping mDNS Service...");
 
   // This closes the socket and removes listeners
   mdns.stop();

--- a/example.ts
+++ b/example.ts
@@ -7,10 +7,13 @@ const mdns = new Core([], null, {
   disableListener: false,
   disablePublisher: false,
 });
-
+mdns.info(`📢 Publishing ${ref}...`);
+mdns.publish(ref, { hello: "world" });
 // // 2. Start Listener
-const event = mdns.listen("MyDevice1\nMyDevice2");
+let event = mdns.listen();
+mdns.stop();
 
+event = mdns.listen("MyDevice1\nMyDevice2");
 // // --- HANDLERS ---
 
 event.on(EmittedEvent.RESPONSE, (found_hostnames: Device[]) => {
@@ -21,15 +24,9 @@ event.on(EmittedEvent.RESPONSE, (found_hostnames: Device[]) => {
 //   mdns.info(`🔎 Discovered [${device.type}]: ${device.name}`, device.data);
 // });
 
-// event.on(EmittedEvent.ERROR, (error: Error) => {
-//   mdns.info("❌ Error:", error.message);
-// });
-
-// --- ACTIONS (Immediate) ---
-
-// Publish immediately
-mdns.info(`📢 Publishing ${ref}...`);
-mdns.publish(ref, { hello: "world" });
+event.on(EmittedEvent.ERROR, (error: Error) => {
+  mdns.info("❌ Error:", error.message);
+});
 
 // Scan immediately (You can run multiple scans at once)
 // mdns.info("🚀 Scanning for ALL Services...");

--- a/example.ts
+++ b/example.ts
@@ -2,38 +2,38 @@ import { Core, Device, EmittedEvent } from "./src";
 // check README examples
 const ref = "MyDevice2";
 // 1. Initialize
-const mdns = new Core([ref], null, {
+const mdns = new Core([], null, {
   debug: false,
   disableListener: false,
   disablePublisher: false,
 });
 
-// 2. Start Listener
-const event = mdns.listen();
+// // 2. Start Listener
+const event = mdns.listen("MyDevice1\nMyDevice2");
 
-// --- HANDLERS ---
+// // --- HANDLERS ---
 
 event.on(EmittedEvent.RESPONSE, (found_hostnames: Device[]) => {
   mdns.info("✅ Found TARGETED Host:", found_hostnames);
 });
 
-event.on(EmittedEvent.DISCOVERY, (device: Device) => {
-  mdns.info(`🔎 Discovered [${device.type}]: ${device.name}`, device.data);
-});
+// event.on(EmittedEvent.DISCOVERY, (device: Device) => {
+//   mdns.info(`🔎 Discovered [${device.type}]: ${device.name}`, device.data);
+// });
 
-event.on(EmittedEvent.ERROR, (error: Error) => {
-  mdns.info("❌ Error:", error.message);
-});
+// event.on(EmittedEvent.ERROR, (error: Error) => {
+//   mdns.info("❌ Error:", error.message);
+// });
 
 // --- ACTIONS (Immediate) ---
 
 // Publish immediately
 mdns.info(`📢 Publishing ${ref}...`);
-mdns.publish(ref);
+mdns.publish(ref, { hello: "world" });
 
 // Scan immediately (You can run multiple scans at once)
-mdns.info("🚀 Scanning for ALL Services...");
-mdns.scan("_services._dns-sd._udp.local");
+// mdns.info("🚀 Scanning for ALL Services...");
+// mdns.scan("_services._dns-sd._udp.local");
 
 // --- GRACEFUL SHUTDOWN (Ctrl + C) ---
 process.on("SIGINT", () => {

--- a/example.ts
+++ b/example.ts
@@ -1,4 +1,5 @@
-import { Core, Device, EmittedEvent } from "./src";
+import { Core, Device, EmittedEvent } from "@/index.js";
+import { EventEmitter } from "node:events";
 // check README examples
 const ref = "MyDevice2";
 // 1. Initialize
@@ -10,10 +11,10 @@ const mdns = new Core([], null, {
 mdns.info(`📢 Publishing ${ref}...`);
 mdns.publish(ref, { hello: "world" });
 // // 2. Start Listener
-let event = mdns.listen();
+const event: EventEmitter = mdns.listen();
 mdns.stop();
 
-event = mdns.listen("MyDevice1\nMyDevice2");
+mdns.listen("MyDevice1\nMyDevice2");
 // // --- HANDLERS ---
 
 event.on(EmittedEvent.RESPONSE, (found_hostnames: Device[]) => {

--- a/example.ts
+++ b/example.ts
@@ -3,18 +3,14 @@ import { EventEmitter } from "node:events";
 // check README examples
 const ref = "MyDevice2";
 // 1. Initialize
-const mdns = new Core([], null, {
-  debug: false,
-  disableListener: false,
-  disablePublisher: false,
-});
+const mdns = new Core();
 mdns.info(`📢 Publishing ${ref}...`);
 mdns.publish(ref, { hello: "world" });
 // // 2. Start Listener
 const event: EventEmitter = mdns.listen();
 mdns.stop();
 
-mdns.listen("MyDevice1\nMyDevice2");
+// mdns.listen("MyDevice1\nMyDevice2");
 // // --- HANDLERS ---
 
 event.on(EmittedEvent.RESPONSE, (found_hostnames: Device[]) => {

--- a/example.ts
+++ b/example.ts
@@ -20,9 +20,9 @@ event.on(EmittedEvent.RESPONSE, (found_hostnames: Device[]) => {
   mdns.info("✅ Found TARGETED Host:", found_hostnames);
 });
 
-// event.on(EmittedEvent.DISCOVERY, (device: Device) => {
-//   mdns.info(`🔎 Discovered [${device.type}]: ${device.name}`, device.data);
-// });
+event.on(EmittedEvent.DISCOVERY, (device: Device) => {
+  mdns.info(`🔎 Discovered [${device.type}]: ${device.name}`, device.data);
+});
 
 event.on(EmittedEvent.ERROR, (error: Error) => {
   mdns.info("❌ Error:", error.message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdns-listener-advanced",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Advanced mDNS listener — discover and publish .local hostnames easily.",
   "author": "aminekun90",
   "license": "MIT",

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -327,10 +327,11 @@ export class Core {
 
     if (this.error) {
       const errorMessage = `Problem in MDNS listener! Report: ${NPM_URL}`;
-      this.myEvent.emit(EmittedEvent.ERROR, new Error(errorMessage));
+      process.nextTick(() => {
+        this.myEvent.emit(EmittedEvent.ERROR, new Error(errorMessage));
+      });
       return this.myEvent;
     }
-
     try {
       this.socket.bind(MDNS_PORT, () => {
         // Mark as listening inside the callback (or assuming success if no sync error)

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -27,7 +27,7 @@ interface Logger {
  * publishing and listening for services on the local network.
  *
  * It is designed to be:
- * - **Zero-Dependency:** Uses native Node.js modules (dgram, crypto, etc).
+ * - **Zero-Dependency:** Uses native Node.js modules (dgram, crypto, etc.).
  * - **Cross-Platform:** Compatible with Windows, macOS, and Linux.
  * - **Resilient:** Handles socket errors, re-binding, and resource cleanup.
  */
@@ -153,7 +153,8 @@ export class Core {
         .map((line) => line.replace(/#.*/, "").trim())
         .filter(Boolean);
       if (!this.hostnames.length) {
-        this.logger.warn("Hosts are empty");
+        this.logger.debug("init listener -> Hosts are empty or not provided");
+        return;
       }
     } catch (err) {
       this.debug(err as Error);
@@ -187,7 +188,8 @@ export class Core {
     this.logger.warn(
       "Hostnames or path to hostnames is not provided, listening to a host might be compromised!",
     );
-    throw new Error(`Provide hostnames or path to hostnames! Report this error ${NPM_URL}`);
+    return "";
+    // throw new Error(`Provide hostnames or path to hostnames! Report this error ${NPM_URL}`);
   }
 
   /**
@@ -324,8 +326,8 @@ export class Core {
     this.__initListener(ref);
 
     if (this.error) {
-      const errorMessage = `Error in MDNS listener! Report: ${NPM_URL}`;
-      process.nextTick(() => this.myEvent.emit(EmittedEvent.ERROR, new Error(errorMessage)));
+      const errorMessage = `Problem in MDNS listener! Report: ${NPM_URL}`;
+      this.myEvent.emit(EmittedEvent.ERROR, new Error(errorMessage));
       return this.myEvent;
     }
 

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -20,7 +20,7 @@ export class SimpleLogger {
       this.useColor = false;
     } else {
       // Safe Node.js check for "Are we in a terminal?"
-      this.useColor = !!process.stdout.isTTY;
+      this.useColor = Boolean(process.stdout.isTTY);
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
   },
   "include": [
     "src/**/*",
-    "__tests__/**/*"
+    "__tests__/**/*",
+    "./example.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Feat: listen method enhancement

- Be able to listen for a host by providing one or multiple hosts

```typescript
// Before this PR
const ref = "Mydevice1";
const mdns = new Core([ref,"Device2"]);// with an empty array an error is triggered
mdns.listen();

// After This PR you can listen for one or multiple hosts separated with "\n"
const mdns = new Core();
mdns.listen("Mydevice1\nDevice2");
// Without any param it will show an error !! 
mdns.listen();
// output : [MDNS ADVANCED] INFO: ❌ Error: Error in MDNS listener! Report: https://www.npmjs.com/package/mdns-listener-advanced
```
- Add unit tests
- Fix for #43 
